### PR TITLE
Corrected volume route for mongodb container

### DIFF
--- a/.scripts/build_mongo.sh
+++ b/.scripts/build_mongo.sh
@@ -2,4 +2,4 @@
 
 # Runs the docker container on port 27017:27017 with name "mongo" on dettached mode
 # more details: when stopped it's deleted and it has a volume on ".cache" directory
-docker run --rm -d --name mongo -p 27017:27017 -v $(pwd)/.cache:/data/db mongo:5.0.3 
+docker run --rm -d --name mongo -p 27017:27017 -v $(pwd)/.cache/db/data:/data/db mongo:5.0.3 


### PR DESCRIPTION
Antes se estaba guardando la data de mongo directamente en ./.cache. Es mejor guardarlo un poco más adentro para poder tener más cosas dentro de .cache, como las migraciones